### PR TITLE
examples: update gas sponsorship & add in-kind sponsorship example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,21 +73,26 @@ print(f"Received bundle: {bundle}")
 
 ## Gas Sponsorship
 
-The Renegade relayer will cover the gas cost of external match transactions, up to a daily limit. When requested, the relayer will re-route the settlement transaction through a gas rebate contract. This contract refunds the cost of the transaction (in ether) to the configured address. If no address is given, the rebate is sent to `tx.origin`. 
+The Renegade relayer will cover the gas cost of external match transactions, up to a daily limit. When requested, the relayer will re-route the settlement transaction through a gas rebate contract. This contract refunds the cost of the transaction, either in native Ether, or in terms of the buy-side token in the external match.
+The rebate can optionally be sent to a configured address.
 
-To request gas sponsorship, simply add `with_gas_sponsorship` to the `AssembleExternalMatchOptions` type:
+For in-kind sponsorship, if no refund address is given, the rebate is sent to the receiver of the match. This is equivalent to the receiver getting a better price in the match, and as such the quoted price returned by the SDK is updated to reflect that.
+
+**In-kind gas sponsorship is enabled by default!**
+
+If, however, you would like to disable gas sponsorship, simply add `with_gas_sponsorship_disabled` to the `RequestQuoteOptions` type:
 ```python
 # Refund address defaults to tx.origin
-options = AssembleExternalMatchOptions.new().with_gas_sponsorship(True).with_gas_refund_address("0xdeadbeef")
-bundle = client.assemble_quote_with_options(quote, options)
-# ... Submit bundle ... #
+options = RequestQuoteOptions.new().with_gas_sponsorship_disabled(True)
+quote = client.request_quote_with_options(quote, options)
+# ... Assemble + submit bundle ... #
 ```
 
-For a full example, see [`examples/gas_sponsorship.py`](examples/gas_sponsorship.py).
+For examples on how to configure gas sponsorship, see [`examples/native_eth_gas_sponsorship.rs`](examples/native_eth_gas_sponsorship.py), and [`examples/in_kind_gas_sponsorship.py`](examples/in_kind_gas_sponsorship.py)
 
 ### Gas Sponsorship Notes
 
-- There is some overhead to the gas rebate contract, so the gas cost paid by the user is non-zero. This value is consistently around **17k gas**, or around **$0.0004** with current gas prices.
+- The refund amount may not exactly equal the gas costs, as this must be estimated before constructing the transaction so it can be returned in the quote.
 - The gas estimate returned by `eth_estimateGas` will _not_ reflect the rebate, as the rebate does not _reduce_ the gas used; it merely refunds the ether paid for the gas. If you wish to understand the true gas cost ahead of time, the transaction can be simulated (e.g. with `alchemy_simulateExecution` or similar).
 - The rate limits currently sponsor up to **~500 matches/day** ($100 in gas). 
 
@@ -102,7 +107,7 @@ The *quote* returned by the relayer for an external match has the following stru
     - `mint`: The token address
     - `amount`: The amount to receive
 - `send`: The asset transfer the external party needs to send. No fees are charged on the send transfer. (same fields as `receive`)
-- `price`: The price used for the match
+- `price`: The price used for the match. If in-kind sponsorship was enabled, and directed to the receiver of the match, this price accounts for the additional tokens received.
 - `timestamp`: The timestamp of the quote
 
 When assembled into a bundle (returned from `assemble_quote` or `request_external_match`), the structure is as follows:

--- a/examples/native_eth_gas_sponsorship.py
+++ b/examples/native_eth_gas_sponsorship.py
@@ -1,0 +1,110 @@
+import os
+import asyncio
+from dotenv import load_dotenv
+from web3 import AsyncWeb3, Web3
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from web3.middleware import SignAndSendRawMiddlewareBuilder
+from renegade import ExternalMatchClient, AssembleExternalMatchOptions, RequestQuoteOptions
+from renegade.types import ExternalMatchResponse, OrderSide, ExternalOrder
+
+# Constants
+BASE_MINT = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a"  # Testnet wETH
+QUOTE_MINT = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"  # Testnet USDC
+GAS_REFUND_ADDRESS = "0x99D9133afE1B9eC1726C077cA2b79Dcbb5969707"
+
+def get_wallet() -> tuple[AsyncWeb3, LocalAccount]:
+    rpc_url = os.getenv("RPC_URL")
+    if not rpc_url:
+        raise ValueError("RPC_URL environment variable not set")
+
+    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(rpc_url))
+    private_key = os.getenv("PKEY")
+    if not private_key:
+        raise ValueError("PKEY environment variable not set")
+    
+    account: LocalAccount = Account.from_key(private_key)
+    w3.eth.default_account = account.address
+    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(private_key), layer=0)
+    
+    return w3, account
+
+async def execute_bundle(bundle: ExternalMatchResponse) -> None:
+    (w3, account) = get_wallet()
+
+    print("\nSubmitting bundle...")
+    tx = bundle.match_bundle.settlement_tx
+    tx['to'] = Web3.to_checksum_address(tx['to'])
+    
+    # Add required transaction fields
+    tx['nonce'] = await w3.eth.get_transaction_count(account.address)
+    
+    # Get current gas prices
+    base_fee = await w3.eth.get_block('latest')
+    max_priority_fee = await w3.eth.max_priority_fee
+    max_fee_per_gas = 2 * base_fee.baseFeePerGas + max_priority_fee
+    
+    tx['maxFeePerGas'] = max_fee_per_gas
+    tx['maxPriorityFeePerGas'] = max_priority_fee
+    tx['chainId'] = await w3.eth.chain_id
+    tx['from'] = account.address
+    
+    # Add gas estimation
+    gas = await w3.eth.estimate_gas(tx)
+    tx['gas'] = int(gas * 1.1)  # Add 10% buffer
+    
+    tx_hash = await w3.eth.send_transaction(tx)
+    print(f"Transaction submitted: 0x{tx_hash.hex()}")
+
+async def fetch_quote_and_execute_with_sponsorship(
+    client: ExternalMatchClient,
+    order: ExternalOrder,
+) -> None:
+    # Fetch a quote from the relayer with native ETH gas sponsorship
+    print("Fetching quote with native ETH gas sponsorship...")
+    # Create options with gas sponsorship enabled
+    options = RequestQuoteOptions.new().with_refund_native_eth(True).with_gas_refund_address(GAS_REFUND_ADDRESS)
+    quote = await client.request_quote_with_options(order, options)
+    if not quote:
+        raise ValueError("No quote found")
+    
+    if not quote.gas_sponsorship_info or not quote.gas_sponsorship_info.gas_sponsorship_info.refund_native_eth:
+        raise ValueError("Quote was not sponsored with native ETH")
+    
+    print("\nAssembling quote...")
+    bundle = await client.assemble_quote(quote)
+    if not bundle:
+        raise ValueError("No bundle found")
+
+    if not bundle.gas_sponsored:
+        print("Gas not sponsored, aborting")
+        return
+
+    # Execute the bundle
+    await execute_bundle(bundle)
+
+async def main():
+    # Load environment variables
+    load_dotenv(override=True)
+
+    # Get the external match client
+    api_key = os.getenv("EXTERNAL_MATCH_KEY")
+    api_secret = os.getenv("EXTERNAL_MATCH_SECRET")
+    if not api_key or not api_secret:
+        raise ValueError("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
+
+    client = ExternalMatchClient.new_sepolia_client(api_key, api_secret)
+
+    # Create the order
+    order = ExternalOrder(
+        base_mint=BASE_MINT,
+        quote_mint=QUOTE_MINT,
+        side=OrderSide.SELL,
+        quote_amount=30_000_000,  # $30 USDC
+        min_fill_size=3_000_000,  # $3 USDC minimum
+    )
+
+    await fetch_quote_and_execute_with_sponsorship(client, order)
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "renegade-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python SDK for Renegade darkpool"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,8 +32,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/renegade-fi/renegade-sdk"
-Documentation = "https://docs.renegade.fi"
+Homepage = "https://renegade.fi/"
+Repository = "https://github.com/renegade-fi/python-sdk"
 
 [tool.hatch.build.targets.wheel]
 packages = ["renegade"]

--- a/renegade/__init__.py
+++ b/renegade/__init__.py
@@ -1,4 +1,4 @@
-from .client import ExternalMatchClient, ExternalMatchOptions, ExternalMatchClientError, AssembleExternalMatchOptions
+from .client import ExternalMatchClient, ExternalMatchOptions, ExternalMatchClientError, AssembleExternalMatchOptions, RequestQuoteOptions
 from .http import RelayerHttpClient
 from .types import ExternalOrder, OrderSide, AtomicMatchApiBundle, SignedExternalQuote
 
@@ -8,6 +8,7 @@ __all__ = [
     "ExternalMatchClient",
     "ExternalMatchOptions",
     "AssembleExternalMatchOptions",
+    "RequestQuoteOptions",
     "ExternalMatchClientError",
     "RelayerHttpClient",
     "ExternalOrder",

--- a/renegade/client.py
+++ b/renegade/client.py
@@ -98,7 +98,8 @@ class RequestQuoteOptions:
         if self.gas_refund_address:
             path += f"&{GAS_REFUND_ADDRESS_QUERY_PARAM}={self.gas_refund_address}"
         if self.refund_native_eth:
-            path += f"&{REFUND_NATIVE_ETH_QUERY_PARAM}={self.refund_native_eth}"
+            refund_native_eth_str = str(self.refund_native_eth).lower()
+            path += f"&{REFUND_NATIVE_ETH_QUERY_PARAM}={refund_native_eth_str}"
 
         return path
 


### PR DESCRIPTION
This PR updates the existing gas sponsorship example to focus in on native ETH sponsorship, and adds an example for in-kind gas sponsorship. Both of these examples run as expected. We also update the README to include information about in-kind gas sponsorship.