### PR TITLE
renegade: client: Add SDK version to headers

### DIFF
--- a/renegade/__init__.py
+++ b/renegade/__init__.py
@@ -1,4 +1,9 @@
-from .client import ExternalMatchClient, ExternalMatchOptions, ExternalMatchClientError, AssembleExternalMatchOptions, RequestQuoteOptions
+"""SDK for interacting with the Renegade darkpool."""
+
+from .client import (
+    ExternalMatchClient, ExternalMatchOptions, ExternalMatchClientError,
+    AssembleExternalMatchOptions, RequestQuoteOptions 
+)
 from .http import RelayerHttpClient
 from .types import ExternalOrder, OrderSide, AtomicMatchApiBundle, SignedExternalQuote
 
@@ -13,4 +18,4 @@ __all__ = [
     "RelayerHttpClient",
     "ExternalOrder",
     "OrderSide",
-] 
+]


### PR DESCRIPTION
### Purpose
This PR adds the SDK version to all request headers. This is formatted as `python-vx.y.z`.

### Testing
- Logged the headers sent in requests for an example.