### PR TITLE
renegade: client, http: Add synchronous client interface

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example package for the Renegade SDK.""" 

--- a/examples/exact_amount.py
+++ b/examples/exact_amount.py
@@ -1,117 +1,28 @@
-import os
+"""Example of executing a trade with an exact output amount."""
+
 import asyncio
-from dotenv import load_dotenv
-from web3 import AsyncWeb3, Web3
-from eth_account import Account
-from eth_account.signers.local import LocalAccount
-from web3.middleware import SignAndSendRawMiddlewareBuilder
-from renegade import ExternalMatchClient
-from renegade.types import ExternalMatchResponse, OrderSide, ExternalOrder
+from renegade import OrderSide, ExternalOrder
+from examples.helpers import BASE_MINT, QUOTE_MINT, get_client, execute_bundle_async
 
-# Constants
-BASE_MINT = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a"  # Testnet wETH
-QUOTE_MINT = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"  # Testnet USDC
-
-def get_wallet() -> tuple[AsyncWeb3, LocalAccount]:
-    """Get a Web3 instance and account from environment variables."""
-    rpc_url = os.getenv("RPC_URL")
-    if not rpc_url:
-        raise ValueError("RPC_URL environment variable not set")
-
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(rpc_url))
-    private_key = os.getenv("PKEY")
-    if not private_key:
-        raise ValueError("PKEY environment variable not set")
-    
-    account: LocalAccount = Account.from_key(private_key)
-    w3.eth.default_account = account.address
-    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(private_key), layer=0)
-    
-    return w3, account
-
-async def execute_bundle(bundle: ExternalMatchResponse) -> None:
-    """Execute a settlement transaction bundle.
-    
-    Args:
-        bundle: The bundle to execute
-    """
-    (w3, account) = get_wallet()
-
-    print("\nSubmitting bundle...")
-    tx = bundle.match_bundle.settlement_tx
-    tx['to'] = Web3.to_checksum_address(tx['to'])
-    
-    # Add required transaction fields
-    tx['nonce'] = await w3.eth.get_transaction_count(account.address)
-    
-    # Get current gas prices
-    base_fee = await w3.eth.get_block('latest')
-    max_priority_fee = await w3.eth.max_priority_fee
-    max_fee_per_gas = 2 * base_fee.baseFeePerGas + max_priority_fee
-    
-    tx['maxFeePerGas'] = max_fee_per_gas
-    tx['maxPriorityFeePerGas'] = max_priority_fee
-    tx['chainId'] = await w3.eth.chain_id
-    tx['from'] = account.address
-    
-    # Add gas estimation
-    gas = await w3.eth.estimate_gas(tx)
-    tx['gas'] = int(gas * 1.1)  # Add 10% buffer
-    
-    tx_hash = await w3.eth.send_transaction(tx)
-    print(f"Transaction submitted: 0x{tx_hash.hex()}")
-
-async def fetch_quote_and_execute(
-    client: ExternalMatchClient,
-    order: ExternalOrder,
-) -> None:
-    """Fetch a quote, validate it, and execute the trade.
-    
-    Args:
-        client: The ExternalMatchClient to use
-        order: The order to request a quote for
-        
-    Raises:
-        ValueError: If no quote is found
-    """
-    # Fetch a quote from the relayer
-    print("Fetching quote...")
-    quote = await client.request_quote(order)
-    if not quote:
-        raise ValueError("No quote found")
-    
-    # Print quote details
-    print(f"\nQuote details:")
-    print(f"Receive amount: {quote.quote.receive.amount}")
-    print(f"Total fees: {quote.quote.fees.total()}")
-    
-    # Assemble the quote into a bundle
-    print("\nAssembling quote...")
-    bundle = await client.assemble_quote(quote)
-    if not bundle:
-        raise ValueError("No bundle found")
-
-    # Execute the bundle
-    await execute_bundle(bundle)
-
-async def main():
-    # Load environment variables
-    load_dotenv(override=True)
-
-    # Get the external match client
-    api_key = os.getenv("EXTERNAL_MATCH_KEY")
-    api_secret = os.getenv("EXTERNAL_MATCH_SECRET")
-    if not api_key or not api_secret:
-        raise ValueError("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
-
-    client = ExternalMatchClient.new_sepolia_client(api_key, api_secret)
+async def fetch_quote_and_execute() -> None:
+    """Fetch a quote and execute the trade."""
+    # Create an order for 1 wETH
     order = ExternalOrder(
         base_mint=BASE_MINT,
         quote_mint=QUOTE_MINT,
-        side=OrderSide.SELL,
-        exact_quote_output=30_000_000,  # $30 USDC
+        side=OrderSide.BUY,
+        exact_quote_output=30_000_000, # $30 USDC
     )
-    await fetch_quote_and_execute(client, order)
+    
+    # Get a quote
+    print("Fetching quote...")
+    client = get_client()
+    quote = await client.request_quote(order)
+    
+    # Assemble and execute the match
+    print("Assembling quote...")
+    bundle = await client.assemble_quote(quote)
+    await execute_bundle_async(bundle)
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(fetch_quote_and_execute())

--- a/examples/external_match.py
+++ b/examples/external_match.py
@@ -1,91 +1,16 @@
-import os
 import asyncio
-from dotenv import load_dotenv
-from web3 import AsyncWeb3, Web3
-from eth_account import Account
-from eth_account.signers.local import LocalAccount
-from web3.middleware import SignAndSendRawMiddlewareBuilder
-from renegade import ExternalMatchClient
-from renegade.types import ExternalMatchResponse, OrderSide, ExternalOrder
+from renegade.types import OrderSide, ExternalOrder
+from examples.helpers import (
+    BASE_MINT, QUOTE_MINT, get_client,
+    execute_bundle_async
+)
 
-# Constants
-BASE_MINT = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a"  # Testnet wETH
-QUOTE_MINT = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"  # Testnet USDC
-
-def get_wallet() -> tuple[AsyncWeb3, LocalAccount]:
-    rpc_url = os.getenv("RPC_URL")
-    if not rpc_url:
-        raise ValueError("RPC_URL environment variable not set")
-
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(rpc_url))
-    private_key = os.getenv("PKEY")
-    if not private_key:
-        raise ValueError("PKEY environment variable not set")
+async def fetch_quote_and_execute() -> None:
+    """Fetch a quote, validate it, and execute the trade.
     
-    account: LocalAccount = Account.from_key(private_key)
-    w3.eth.default_account = account.address
-    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(private_key), layer=0)
-    
-    return w3, account
-
-async def execute_bundle(bundle: ExternalMatchResponse) -> None:
-    (w3, account) = get_wallet()
-
-    print("\nSubmitting bundle...")
-    tx = bundle.match_bundle.settlement_tx
-    tx['to'] = Web3.to_checksum_address(tx['to'])
-    
-    # Add required transaction fields
-    tx['nonce'] = await w3.eth.get_transaction_count(account.address)
-    
-    # Get current gas prices
-    base_fee = await w3.eth.get_block('latest')
-    max_priority_fee = await w3.eth.max_priority_fee
-    max_fee_per_gas = 2 * base_fee.baseFeePerGas + max_priority_fee
-    
-    tx['maxFeePerGas'] = max_fee_per_gas
-    tx['maxPriorityFeePerGas'] = max_priority_fee
-    tx['chainId'] = await w3.eth.chain_id
-    tx['from'] = account.address
-    
-    # Add gas estimation
-    gas = await w3.eth.estimate_gas(tx)
-    tx['gas'] = int(gas * 1.1)  # Add 10% buffer
-    
-    tx_hash = await w3.eth.send_transaction(tx)
-    print(f"Transaction submitted: 0x{tx_hash.hex()}")
-
-async def fetch_quote_and_execute(
-    client: ExternalMatchClient,
-    order: ExternalOrder,
-) -> None:
-    # Fetch a quote from the relayer
-    print("Fetching quote...")
-    quote = await client.request_quote(order)
-    if not quote:
-        raise ValueError("No quote found")
-    
-    # Assemble the quote into a bundle
-    print("\nAssembling quote...")
-    bundle = await client.assemble_quote(quote)
-    if not bundle:
-        raise ValueError("No bundle found")
-
-    # Execute the bundle
-    await execute_bundle(bundle)
-
-async def main():
-    # Load environment variables
-    load_dotenv(override=True)
-
-    # Get the external match client
-    api_key = os.getenv("EXTERNAL_MATCH_KEY")
-    api_secret = os.getenv("EXTERNAL_MATCH_SECRET")
-    if not api_key or not api_secret:
-        raise ValueError("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
-
-    client = ExternalMatchClient.new_sepolia_client(api_key, api_secret)
-
+    Raises:
+        ValueError: If no quote is found
+    """
     # Create the order
     order = ExternalOrder(
         base_mint=BASE_MINT,
@@ -95,7 +20,26 @@ async def main():
         min_fill_size=3_000_000,  # $3 USDC minimum
     )
 
-    await fetch_quote_and_execute(client, order)
+    # Fetch a quote from the relayer
+    print("Fetching quote...")
+    client = get_client()
+    quote = await client.request_quote(order)
+    if not quote:
+        raise ValueError("No quote found")
+    
+    # Print quote details
+    print(f"\nQuote details:")
+    print(f"Receive amount: {quote.quote.receive.amount}")
+    print(f"Total fees: {quote.quote.fees.total()}")
+    
+    # Assemble the quote into a bundle
+    print("\nAssembling quote...")
+    bundle = await client.assemble_quote(quote)
+    if not bundle:
+        raise ValueError("No bundle found")
+
+    # Execute the bundle
+    await execute_bundle_async(bundle)
 
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(fetch_quote_and_execute()) 

--- a/examples/helpers.py
+++ b/examples/helpers.py
@@ -1,0 +1,122 @@
+import os
+from typing import Tuple, Optional
+from dotenv import load_dotenv
+from web3 import Web3, AsyncWeb3
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from web3.middleware import SignAndSendRawMiddlewareBuilder
+from renegade import ExternalMatchClient
+from renegade.types import ExternalMatchResponse
+
+# Common constants
+BASE_MINT = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a"  # Testnet wETH
+QUOTE_MINT = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"  # Testnet USDC
+
+def get_wallet(is_async: bool = True) -> Tuple[Web3 | AsyncWeb3, LocalAccount]:
+    """Get a Web3 instance and account from environment variables.
+    
+    Args:
+        is_async: Whether to return an async Web3 instance
+        
+    Returns:
+        A tuple of (Web3 instance, LocalAccount)
+        
+    Raises:
+        ValueError: If required environment variables are not set
+    """
+    rpc_url = os.getenv("RPC_URL")
+    if not rpc_url:
+        raise ValueError("RPC_URL environment variable not set")
+
+    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(rpc_url)) if is_async else Web3(Web3.HTTPProvider(rpc_url))
+    private_key = os.getenv("PKEY")
+    if not private_key:
+        raise ValueError("PKEY environment variable not set")
+    
+    account: LocalAccount = Account.from_key(private_key)
+    w3.eth.default_account = account.address
+    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(private_key), layer=0)
+    
+    return w3, account
+
+async def execute_bundle_async(bundle: ExternalMatchResponse) -> None:
+    """Execute a settlement transaction bundle asynchronously.
+    
+    Args:
+        bundle: The bundle to execute
+    """
+    (w3, account) = get_wallet(is_async=True)
+
+    print("Submitting bundle...")
+    tx = bundle.match_bundle.settlement_tx
+    tx['to'] = Web3.to_checksum_address(tx['to'])
+    
+    # Add required transaction fields
+    tx['nonce'] = await w3.eth.get_transaction_count(account.address)
+    
+    # Get current gas prices
+    base_fee = await w3.eth.get_block('latest')
+    max_priority_fee = await w3.eth.max_priority_fee
+    max_fee_per_gas = 2 * base_fee.baseFeePerGas + max_priority_fee
+    
+    tx['maxFeePerGas'] = max_fee_per_gas
+    tx['maxPriorityFeePerGas'] = max_priority_fee
+    tx['chainId'] = await w3.eth.chain_id
+    tx['from'] = account.address
+    
+    # Add gas estimation
+    gas = await w3.eth.estimate_gas(tx)
+    tx['gas'] = int(gas * 1.1)  # Add 10% buffer
+    
+    tx_hash = await w3.eth.send_transaction(tx)
+    print(f"Transaction submitted: 0x{tx_hash.hex()}")
+
+def execute_bundle_sync(bundle: ExternalMatchResponse) -> None:
+    """Execute a settlement transaction bundle synchronously.
+    
+    Args:
+        bundle: The bundle to execute
+    """
+    (w3, account) = get_wallet(is_async=False)
+
+    print("Submitting bundle...")
+    tx = bundle.match_bundle.settlement_tx
+    tx['to'] = Web3.to_checksum_address(tx['to'])
+    
+    # Add required transaction fields
+    tx['nonce'] = w3.eth.get_transaction_count(account.address)
+    
+    # Get current gas prices
+    base_fee = w3.eth.get_block('latest')
+    max_priority_fee = w3.eth.max_priority_fee
+    max_fee_per_gas = 2 * base_fee.baseFeePerGas + max_priority_fee
+    
+    tx['maxFeePerGas'] = max_fee_per_gas
+    tx['maxPriorityFeePerGas'] = max_priority_fee
+    tx['chainId'] = w3.eth.chain_id
+    tx['from'] = account.address
+    
+    # Add gas estimation
+    gas = w3.eth.estimate_gas(tx)
+    tx['gas'] = int(gas * 1.1)  # Add 10% buffer
+    
+    tx_hash = w3.eth.send_transaction(tx)
+    print(f"Transaction submitted: 0x{tx_hash.hex()}")
+
+def get_client() -> ExternalMatchClient:
+    """Get an ExternalMatchClient instance from environment variables.
+    
+    Returns:
+        An ExternalMatchClient instance configured for Sepolia testnet
+        
+    Raises:
+        ValueError: If required environment variables are not set
+    """
+    load_dotenv(override=True)
+    
+    api_key = os.getenv("EXTERNAL_MATCH_KEY")
+    api_secret = os.getenv("EXTERNAL_MATCH_SECRET")
+    if not api_key or not api_secret:
+        raise ValueError("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
+
+    return ExternalMatchClient.new_sepolia_client(api_key, api_secret) 

--- a/examples/in_kind_gas_sponsorship.py
+++ b/examples/in_kind_gas_sponsorship.py
@@ -1,103 +1,14 @@
-import os
+"""Example of executing a trade with in-kind gas sponsorship."""
+
 import asyncio
-from dotenv import load_dotenv
-from web3 import AsyncWeb3, Web3
-from eth_account import Account
-from eth_account.signers.local import LocalAccount
-from web3.middleware import SignAndSendRawMiddlewareBuilder
-from renegade import ExternalMatchClient, AssembleExternalMatchOptions, RequestQuoteOptions
-from renegade.types import ExternalMatchResponse, OrderSide, ExternalOrder
+from renegade import  OrderSide, ExternalOrder
+from examples.helpers import BASE_MINT, QUOTE_MINT, get_client, execute_bundle_async
 
 # Constants
-BASE_MINT = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a"  # Testnet wETH
-QUOTE_MINT = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"  # Testnet USDC
 GAS_REFUND_ADDRESS = "0x99D9133afE1B9eC1726C077cA2b79Dcbb5969707"
 
-def get_wallet() -> tuple[AsyncWeb3, LocalAccount]:
-    rpc_url = os.getenv("RPC_URL")
-    if not rpc_url:
-        raise ValueError("RPC_URL environment variable not set")
-
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(rpc_url))
-    private_key = os.getenv("PKEY")
-    if not private_key:
-        raise ValueError("PKEY environment variable not set")
-    
-    account: LocalAccount = Account.from_key(private_key)
-    w3.eth.default_account = account.address
-    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(private_key), layer=0)
-    
-    return w3, account
-
-async def execute_bundle(bundle: ExternalMatchResponse) -> None:
-    (w3, account) = get_wallet()
-
-    print("\nSubmitting bundle...")
-    tx = bundle.match_bundle.settlement_tx
-    tx['to'] = Web3.to_checksum_address(tx['to'])
-    
-    # Add required transaction fields
-    tx['nonce'] = await w3.eth.get_transaction_count(account.address)
-    
-    # Get current gas prices
-    base_fee = await w3.eth.get_block('latest')
-    max_priority_fee = await w3.eth.max_priority_fee
-    max_fee_per_gas = 2 * base_fee.baseFeePerGas + max_priority_fee
-    
-    tx['maxFeePerGas'] = max_fee_per_gas
-    tx['maxPriorityFeePerGas'] = max_priority_fee
-    tx['chainId'] = await w3.eth.chain_id
-    tx['from'] = account.address
-    
-    # Add gas estimation
-    gas = await w3.eth.estimate_gas(tx)
-    tx['gas'] = int(gas * 1.1)  # Add 10% buffer
-    
-    tx_hash = await w3.eth.send_transaction(tx)
-    print(f"Transaction submitted: 0x{tx_hash.hex()}")
-
-async def fetch_quote_and_execute_with_sponsorship(
-    client: ExternalMatchClient,
-    order: ExternalOrder,
-) -> None:
-    # Fetch a quote from the relayer with in-kind gas sponsorship.
-    # Note that this is the default behavior, so no options need to be set.
-    # Also note: When you leave the `refund_address` unset, the in-kind refund is
-    # directed to the receiver address. This is equivalent to the trade itself
-    # having a better price, so the price in the quote will be updated to
-    # reflect this
-    print("Fetching quote with in-kind gas sponsorship...")
-    quote = await client.request_quote(order)
-    if not quote:
-        raise ValueError("No quote found")
-
-    if not quote.gas_sponsorship_info or quote.gas_sponsorship_info.gas_sponsorship_info.refund_native_eth:
-        raise ValueError("Quote was not sponsored in-kind")
-
-    print("\nAssembling quote...")
-    bundle = await client.assemble_quote(quote)
-    if not bundle:
-        raise ValueError("No bundle found")
-
-    if not bundle.gas_sponsored:
-        print("Gas not sponsored, aborting")
-        return
-
-    # Execute the bundle
-    await execute_bundle(bundle)
-
-async def main():
-    # Load environment variables
-    load_dotenv(override=True)
-
-    # Get the external match client
-    api_key = os.getenv("EXTERNAL_MATCH_KEY")
-    api_secret = os.getenv("EXTERNAL_MATCH_SECRET")
-    if not api_key or not api_secret:
-        raise ValueError("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
-
-    client = ExternalMatchClient.new_sepolia_client(api_key, api_secret)
-
+async def fetch_quote_and_execute() -> None:
+    """Fetch a quote and execute the trade."""
     # Create the order
     order = ExternalOrder(
         base_mint=BASE_MINT,
@@ -106,8 +17,31 @@ async def main():
         quote_amount=30_000_000,  # $30 USDC
         min_fill_size=3_000_000,  # $3 USDC minimum
     )
+    
+    # Fetch a quote from the relayer with in-kind gas sponsorship.
+    # Note that this is the default behavior, so no options need to be set.
+    # Also note: When you leave the `refund_address` unset, the in-kind refund is
+    # directed to the receiver address. This is equivalent to the trade itself
+    # having a better price, so the price in the quote will be updated to
+    # reflect this
+    print("Fetching quote...")
+    client = get_client()
+    quote = await client.request_quote(order)
+    if not quote:
+        raise ValueError("No quote found")
 
-    await fetch_quote_and_execute_with_sponsorship(client, order)
+    # Check for sponsorship
+    if not quote.gas_sponsorship_info or quote.gas_sponsorship_info.gas_sponsorship_info.refund_native_eth:
+            raise ValueError("Quote was not sponsored in-kind")
+    
+    # Assemble and execute the match
+    print("Assembling quote...")
+    bundle = await client.assemble_quote(quote)
+    if not bundle.gas_sponsored:
+        print("Gas not sponsored, aborting")
+        return
+
+    await execute_bundle_async(bundle)
 
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(fetch_quote_and_execute()) 

--- a/examples/modify_order_before_assembly.py
+++ b/examples/modify_order_before_assembly.py
@@ -1,119 +1,16 @@
-import os
+"""Example of modifying an order before assembly."""
+
 import asyncio
-from dotenv import load_dotenv
-from web3 import AsyncWeb3, Web3
-from eth_account import Account
-from eth_account.signers.local import LocalAccount
-from web3.middleware import SignAndSendRawMiddlewareBuilder
-from renegade import ExternalMatchClient
+from renegade import OrderSide, ExternalOrder
 from renegade.client import AssembleExternalMatchOptions
-from renegade.types import (
-    ExternalMatchResponse,
-    OrderSide,
-    ExternalOrder,
-)
+from examples.helpers import BASE_MINT, QUOTE_MINT, get_client, execute_bundle_async
 
 # Constants
 BASE_MINT = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a"  # Testnet wETH
 QUOTE_MINT = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"  # Testnet USDC
 
-# Validation constants
-MIN_AMOUNT = 1000000000000000  # 0.001 WETH
-MAX_FEE = 100000000000000  # 0.0001 WETH
-
-def get_wallet() -> tuple[AsyncWeb3, LocalAccount]:
-    """Get a Web3 instance and account from environment variables."""
-    rpc_url = os.getenv("RPC_URL")
-    if not rpc_url:
-        raise ValueError("RPC_URL environment variable not set")
-
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(rpc_url))
-    private_key = os.getenv("PKEY")
-    if not private_key:
-        raise ValueError("PKEY environment variable not set")
-    
-    account: LocalAccount = Account.from_key(private_key)
-    w3.eth.default_account = account.address
-    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(private_key), layer=0)
-    
-    return w3, account
-
-async def execute_bundle(bundle: ExternalMatchResponse) -> None:
-    """Execute a settlement transaction bundle.
-    
-    Args:
-        bundle: The bundle to execute
-    """
-    (w3, account) = get_wallet()
-
-    print("\nSubmitting bundle...")
-    tx = bundle.match_bundle.settlement_tx
-    tx['to'] = Web3.to_checksum_address(tx['to'])
-    
-    # Add required transaction fields
-    tx['nonce'] = await w3.eth.get_transaction_count(account.address)
-    
-    # Get current gas prices
-    base_fee = await w3.eth.get_block('latest')
-    max_priority_fee = await w3.eth.max_priority_fee
-    max_fee_per_gas = 2 * base_fee.baseFeePerGas + max_priority_fee
-    
-    tx['maxFeePerGas'] = max_fee_per_gas
-    tx['maxPriorityFeePerGas'] = max_priority_fee
-    tx['chainId'] = await w3.eth.chain_id
-    tx['from'] = account.address
-    
-    # Add gas estimation
-    gas = await w3.eth.estimate_gas(tx)
-    tx['gas'] = int(gas * 1.1)  # Add 10% buffer
-    
-    tx_hash = await w3.eth.send_transaction(tx)
-    print(f"Transaction submitted: 0x{tx_hash.hex()}")
-
-async def fetch_quote_and_execute(
-    client: ExternalMatchClient,
-    order: ExternalOrder,
-) -> None:
-    """Fetch a quote, validate it, and execute the trade.
-    
-    Args:
-        client: The ExternalMatchClient to use
-        order: The order to request a quote for
-        
-    Raises:
-        ValueError: If no quote is found or validation fails
-    """
-    # Fetch a quote from the relayer
-    print("Fetching quote...")
-    quote = await client.request_quote(order)
-    if not quote:
-        raise ValueError("No quote found")
-    
-    # Assemble the quote into a bundle
-    print("\nAssembling quote...")
-
-    # Modify the order before assembly
-    order.quote_amount = 19_000_000  # 19 USDC
-    options = AssembleExternalMatchOptions().with_updated_order(order)
-    bundle = await client.assemble_quote_with_options(quote, options)
-    if not bundle:
-        raise ValueError("No bundle found")
-
-    # Execute the bundle
-    await execute_bundle(bundle)
-
-async def main():
-    # Load environment variables
-    load_dotenv(override=True)
-
-    # Get the external match client
-    api_key = os.getenv("EXTERNAL_MATCH_KEY")
-    api_secret = os.getenv("EXTERNAL_MATCH_SECRET")
-    if not api_key or not api_secret:
-        raise ValueError("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
-
-    client = ExternalMatchClient.new_sepolia_client(api_key, api_secret)
-
+async def fetch_quote_and_execute() -> None:
+    """Fetch a quote, modify it, and execute the trade."""
     # Create the order
     order = ExternalOrder(
         base_mint=BASE_MINT,
@@ -122,8 +19,22 @@ async def main():
         quote_amount=20_000_000,  # 20 USDC
         min_fill_size=1000000000000000,  # 0.001 WETH minimum
     )
-
-    await fetch_quote_and_execute(client, order)
+    
+    # Get a quote
+    print("Fetching quote...")
+    client = get_client()
+    signed_quote = await client.request_quote(order)
+    
+    # Modify the order before assembly
+    print("Assembling quote...")
+    order.quote_amount = 19_000_000  # 19 USDC
+    options = AssembleExternalMatchOptions().with_updated_order(order)
+    bundle = await client.assemble_quote_with_options(signed_quote, options)
+    if not bundle:
+        raise ValueError("No bundle found")
+    
+    # Execute the bundle
+    await execute_bundle_async(bundle)
 
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(fetch_quote_and_execute()) 

--- a/examples/native_eth_gas_sponsorship.py
+++ b/examples/native_eth_gas_sponsorship.py
@@ -1,68 +1,27 @@
-import os
+"""Example of executing a trade with native ETH gas sponsorship."""
+
 import asyncio
-from dotenv import load_dotenv
-from web3 import AsyncWeb3, Web3
-from eth_account import Account
-from eth_account.signers.local import LocalAccount
-from web3.middleware import SignAndSendRawMiddlewareBuilder
-from renegade import ExternalMatchClient, AssembleExternalMatchOptions, RequestQuoteOptions
-from renegade.types import ExternalMatchResponse, OrderSide, ExternalOrder
+from renegade import OrderSide, ExternalOrder
+from examples.helpers import BASE_MINT, QUOTE_MINT, get_client, execute_bundle_async
+from renegade.client import RequestQuoteOptions
 
 # Constants
-BASE_MINT = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a"  # Testnet wETH
-QUOTE_MINT = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"  # Testnet USDC
 GAS_REFUND_ADDRESS = "0x99D9133afE1B9eC1726C077cA2b79Dcbb5969707"
 
-def get_wallet() -> tuple[AsyncWeb3, LocalAccount]:
-    rpc_url = os.getenv("RPC_URL")
-    if not rpc_url:
-        raise ValueError("RPC_URL environment variable not set")
-
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(rpc_url))
-    private_key = os.getenv("PKEY")
-    if not private_key:
-        raise ValueError("PKEY environment variable not set")
+async def fetch_quote_and_execute() -> None:
+    """Fetch a quote and execute the trade."""
+    # Create the order
+    order = ExternalOrder(
+        base_mint=BASE_MINT,
+        quote_mint=QUOTE_MINT,
+        side=OrderSide.SELL,
+        quote_amount=30_000_000,  # $30 USDC
+        min_fill_size=3_000_000,  # $3 USDC minimum
+    )
     
-    account: LocalAccount = Account.from_key(private_key)
-    w3.eth.default_account = account.address
-    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(private_key), layer=0)
-    
-    return w3, account
-
-async def execute_bundle(bundle: ExternalMatchResponse) -> None:
-    (w3, account) = get_wallet()
-
-    print("\nSubmitting bundle...")
-    tx = bundle.match_bundle.settlement_tx
-    tx['to'] = Web3.to_checksum_address(tx['to'])
-    
-    # Add required transaction fields
-    tx['nonce'] = await w3.eth.get_transaction_count(account.address)
-    
-    # Get current gas prices
-    base_fee = await w3.eth.get_block('latest')
-    max_priority_fee = await w3.eth.max_priority_fee
-    max_fee_per_gas = 2 * base_fee.baseFeePerGas + max_priority_fee
-    
-    tx['maxFeePerGas'] = max_fee_per_gas
-    tx['maxPriorityFeePerGas'] = max_priority_fee
-    tx['chainId'] = await w3.eth.chain_id
-    tx['from'] = account.address
-    
-    # Add gas estimation
-    gas = await w3.eth.estimate_gas(tx)
-    tx['gas'] = int(gas * 1.1)  # Add 10% buffer
-    
-    tx_hash = await w3.eth.send_transaction(tx)
-    print(f"Transaction submitted: 0x{tx_hash.hex()}")
-
-async def fetch_quote_and_execute_with_sponsorship(
-    client: ExternalMatchClient,
-    order: ExternalOrder,
-) -> None:
-    # Fetch a quote from the relayer with native ETH gas sponsorship
-    print("Fetching quote with native ETH gas sponsorship...")
-    # Create options with gas sponsorship enabled
+    # Fetch a quote with native ETH gas sponsorship
+    print("Fetching quote...")
+    client = get_client()
     options = RequestQuoteOptions.new().with_refund_native_eth(True).with_gas_refund_address(GAS_REFUND_ADDRESS)
     quote = await client.request_quote_with_options(order, options)
     if not quote:
@@ -75,36 +34,8 @@ async def fetch_quote_and_execute_with_sponsorship(
     bundle = await client.assemble_quote(quote)
     if not bundle:
         raise ValueError("No bundle found")
-
-    if not bundle.gas_sponsored:
-        print("Gas not sponsored, aborting")
-        return
-
-    # Execute the bundle
-    await execute_bundle(bundle)
-
-async def main():
-    # Load environment variables
-    load_dotenv(override=True)
-
-    # Get the external match client
-    api_key = os.getenv("EXTERNAL_MATCH_KEY")
-    api_secret = os.getenv("EXTERNAL_MATCH_SECRET")
-    if not api_key or not api_secret:
-        raise ValueError("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
-
-    client = ExternalMatchClient.new_sepolia_client(api_key, api_secret)
-
-    # Create the order
-    order = ExternalOrder(
-        base_mint=BASE_MINT,
-        quote_mint=QUOTE_MINT,
-        side=OrderSide.SELL,
-        quote_amount=30_000_000,  # $30 USDC
-        min_fill_size=3_000_000,  # $3 USDC minimum
-    )
-
-    await fetch_quote_and_execute_with_sponsorship(client, order)
+    
+    await execute_bundle_async(bundle)
 
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(fetch_quote_and_execute()) 

--- a/examples/quote_validation.py
+++ b/examples/quote_validation.py
@@ -1,146 +1,33 @@
-import os
+"""Example of validating a quote before execution."""
+
 import asyncio
-from dotenv import load_dotenv
-from web3 import AsyncWeb3, Web3
-from eth_account import Account
-from eth_account.signers.local import LocalAccount
-from web3.middleware import SignAndSendRawMiddlewareBuilder
-from renegade import ExternalMatchClient
-from renegade.types import (
-    ExternalMatchResponse,
-    OrderSide,
-    ExternalOrder,
-    ApiExternalQuote,
-)
+from renegade import OrderSide, ExternalOrder
+from examples.helpers import BASE_MINT, QUOTE_MINT, get_client, execute_bundle_async
 
-# Constants
-BASE_MINT = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a"  # Testnet wETH
-QUOTE_MINT = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"  # Testnet USDC
-
-# Validation constants
-MIN_AMOUNT = 1000000000000000  # 0.001 WETH
-MAX_FEE = 100000000000000  # 0.0001 WETH
-
-def get_wallet() -> tuple[AsyncWeb3, LocalAccount]:
-    """Get a Web3 instance and account from environment variables."""
-    rpc_url = os.getenv("RPC_URL")
-    if not rpc_url:
-        raise ValueError("RPC_URL environment variable not set")
-
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(rpc_url))
-    private_key = os.getenv("PKEY")
-    if not private_key:
-        raise ValueError("PKEY environment variable not set")
-    
-    account: LocalAccount = Account.from_key(private_key)
-    w3.eth.default_account = account.address
-    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(private_key), layer=0)
-    
-    return w3, account
-
-async def validate_quote(quote: ApiExternalQuote) -> None:
-    """Validate a quote against minimum amount and maximum fee thresholds.
-    
-    Args:
-        quote: The quote to validate
-        
-    Raises:
-        ValueError: If the quote fails validation
-    """
-    total_fee = quote.fees.total()
-    recv_amount = quote.receive.amount
-
-    if recv_amount < MIN_AMOUNT:
-        raise ValueError(f"Received amount {recv_amount} is less than the minimum amount {MIN_AMOUNT}")
-
-    if total_fee > MAX_FEE:
-        raise ValueError(f"Total fee {total_fee} is greater than the maximum fee {MAX_FEE}")
-
-async def execute_bundle(bundle: ExternalMatchResponse) -> None:
-    """Execute a settlement transaction bundle.
-    
-    Args:
-        bundle: The bundle to execute
-    """
-    (w3, account) = get_wallet()
-
-    print("\nSubmitting bundle...")
-    tx = bundle.match_bundle.settlement_tx
-    tx['to'] = Web3.to_checksum_address(tx['to'])
-    
-    # Add required transaction fields
-    tx['nonce'] = await w3.eth.get_transaction_count(account.address)
-    
-    # Get current gas prices
-    base_fee = await w3.eth.get_block('latest')
-    max_priority_fee = await w3.eth.max_priority_fee
-    max_fee_per_gas = 2 * base_fee.baseFeePerGas + max_priority_fee
-    
-    tx['maxFeePerGas'] = max_fee_per_gas
-    tx['maxPriorityFeePerGas'] = max_priority_fee
-    tx['chainId'] = await w3.eth.chain_id
-    tx['from'] = account.address
-    
-    # Add gas estimation
-    gas = await w3.eth.estimate_gas(tx)
-    tx['gas'] = int(gas * 1.1)  # Add 10% buffer
-    
-    tx_hash = await w3.eth.send_transaction(tx)
-    print(f"Transaction submitted: 0x{tx_hash.hex()}")
-
-async def fetch_quote_and_execute(
-    client: ExternalMatchClient,
-    order: ExternalOrder,
-) -> None:
-    """Fetch a quote, validate it, and execute the trade.
-    
-    Args:
-        client: The ExternalMatchClient to use
-        order: The order to request a quote for
-        
-    Raises:
-        ValueError: If no quote is found or validation fails
-    """
-    # Fetch a quote from the relayer
-    print("Fetching quote...")
-    quote = await client.request_quote(order)
-    if not quote:
-        raise ValueError("No quote found")
-    
-    # Validate the quote
-    await validate_quote(quote.quote)
-    
-    # Assemble the quote into a bundle
-    print("\nAssembling quote...")
-    bundle = await client.assemble_quote(quote)
-    if not bundle:
-        raise ValueError("No bundle found")
-
-    # Execute the bundle
-    await execute_bundle(bundle)
-
-async def main():
-    # Load environment variables
-    load_dotenv(override=True)
-
-    # Get the external match client
-    api_key = os.getenv("EXTERNAL_MATCH_KEY")
-    api_secret = os.getenv("EXTERNAL_MATCH_SECRET")
-    if not api_key or not api_secret:
-        raise ValueError("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
-
-    client = ExternalMatchClient.new_sepolia_client(api_key, api_secret)
-
+async def fetch_quote_and_execute() -> None:
+    """Fetch a quote, validate it, and execute the trade."""
     # Create the order
     order = ExternalOrder(
         base_mint=BASE_MINT,
         quote_mint=QUOTE_MINT,
         side=OrderSide.BUY,
-        base_amount=8000000000000000,  # 0.8 WETH
-        min_fill_size=1000000000000000,  # 0.001 WETH minimum
+        base_amount=8_000_000_000_000_000,  # 0.008 WETH
+        min_fill_size=1_000_000_000_000_000,  # 0.001 wETH minimum
     )
-
-    await fetch_quote_and_execute(client, order)
+    
+    # Get a quote
+    print("Fetching quote...")
+    client = get_client()
+    quote = await client.request_quote(order)
+        
+    # Check if the quote meets our minimum requirements
+    if quote.quote.fees.total() > 4_000_000_000_000:  # Less than 1 wETH
+        raise ValueError("Quote fees too high")
+    
+    # Assemble and execute the match
+    print("Assembling quote...")
+    bundle = await client.assemble_quote(quote)
+    await execute_bundle_async(bundle)
 
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(fetch_quote_and_execute()) 

--- a/examples/sync_external_match.py
+++ b/examples/sync_external_match.py
@@ -1,0 +1,100 @@
+import os
+from dotenv import load_dotenv
+from web3 import Web3
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from web3.middleware import SignAndSendRawMiddlewareBuilder
+from renegade import ExternalMatchClient
+from renegade.types import ExternalMatchResponse, OrderSide, ExternalOrder
+
+# Constants
+BASE_MINT = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a"  # Testnet wETH
+QUOTE_MINT = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"  # Testnet USDC
+
+def get_wallet() -> tuple[Web3, LocalAccount]:
+    rpc_url = os.getenv("RPC_URL")
+    if not rpc_url:
+        raise ValueError("RPC_URL environment variable not set")
+
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
+    private_key = os.getenv("PKEY")
+    if not private_key:
+        raise ValueError("PKEY environment variable not set")
+    
+    account: LocalAccount = Account.from_key(private_key)
+    w3.eth.default_account = account.address
+    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(private_key), layer=0)
+    
+    return w3, account
+
+def execute_bundle(bundle: ExternalMatchResponse) -> None:
+    (w3, account) = get_wallet()
+
+    print("\nSubmitting bundle...")
+    tx = bundle.match_bundle.settlement_tx
+    tx['to'] = Web3.to_checksum_address(tx['to'])
+    
+    # Add required transaction fields
+    tx['nonce'] = w3.eth.get_transaction_count(account.address)
+    
+    # Get current gas prices
+    base_fee = w3.eth.get_block('latest')
+    max_priority_fee = w3.eth.max_priority_fee
+    max_fee_per_gas = 2 * base_fee.baseFeePerGas + max_priority_fee
+    
+    tx['maxFeePerGas'] = max_fee_per_gas
+    tx['maxPriorityFeePerGas'] = max_priority_fee
+    tx['chainId'] = w3.eth.chain_id
+    tx['from'] = account.address
+    
+    # Add gas estimation
+    gas = w3.eth.estimate_gas(tx)
+    tx['gas'] = int(gas * 1.1)  # Add 10% buffer
+    
+    tx_hash = w3.eth.send_transaction(tx)
+    print(f"Transaction submitted: 0x{tx_hash.hex()}")
+
+def fetch_quote_and_execute(
+    client: ExternalMatchClient,
+    order: ExternalOrder,
+) -> None:
+    # Fetch a quote from the relayer
+    print("Fetching quote...")
+    quote = client.request_quote_sync(order)
+    if not quote:
+        raise ValueError("No quote found")
+    
+    # Assemble the quote into a bundle
+    print("\nAssembling quote...")
+    bundle = client.assemble_quote_sync(quote)
+    if not bundle:
+        raise ValueError("No bundle found")
+
+    # Execute the bundle
+    execute_bundle(bundle)
+
+def main():
+    # Load environment variables
+    load_dotenv(override=True)
+
+    # Get the external match client
+    api_key = os.getenv("EXTERNAL_MATCH_KEY")
+    api_secret = os.getenv("EXTERNAL_MATCH_SECRET")
+    if not api_key or not api_secret:
+        raise ValueError("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
+
+    client = ExternalMatchClient.new_sepolia_client(api_key, api_secret)
+
+    # Create the order
+    order = ExternalOrder(
+        base_mint=BASE_MINT,
+        quote_mint=QUOTE_MINT,
+        side=OrderSide.SELL,
+        quote_amount=30_000_000,  # $30 USDC
+        min_fill_size=3_000_000,  # $3 USDC minimum
+    )
+
+    fetch_quote_and_execute(client, order)
+
+if __name__ == "__main__":
+    main() 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "renegade-sdk"
-version = "0.1.3"
+version = "0.1.4"
 description = "Python SDK for Renegade darkpool"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
### Purpose
This PR adds synchronous request methods for the SDK client, allowing the renegade SDK to be used in either an async or synchronous python runtime.

I also cleaned up the examples directory to factor all common patterns into a `helpers.py` file.

### Testing
- [x] All examples run and have the expected behavior