### PR TITLE
renegade: client, types: remove sponsorship from assembly req

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "renegade-sdk"
-version = "0.1.4"
+version = "0.1.5"
 description = "Python SDK for Renegade darkpool"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/renegade/client.py
+++ b/renegade/client.py
@@ -378,7 +378,6 @@ class ExternalMatchClient:
             receiver_address=options.receiver_address,
             signed_quote=signed_quote,
             updated_order=options.updated_order,
-            gas_sponsorship_info=quote.gas_sponsorship_info,
         )
 
         path = options.build_request_path()
@@ -416,7 +415,6 @@ class ExternalMatchClient:
             receiver_address=options.receiver_address,
             signed_quote=signed_quote,
             updated_order=options.updated_order,
-            gas_sponsorship_info=quote.gas_sponsorship_info,
         )
 
         path = options.build_request_path()

--- a/renegade/types.py
+++ b/renegade/types.py
@@ -149,4 +149,3 @@ class AssembleExternalMatchRequest(BaseModelWithConfig):
     receiver_address: Optional[str] = None
     signed_quote: Optional[ApiSignedExternalQuote] = None
     updated_order: Optional[ExternalOrder] = None
-    gas_sponsorship_info: Optional[SignedGasSponsorshipInfo] = None


### PR DESCRIPTION
This PR removes the `gas_sponsorship_info` field from the quote assembly request.

### Testing
- [x] Ran all examples, confirmed they execute as expected.