### PR TITLE
renegade: types, client: Expose shared bundles option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ uv run examples/quote_validation.py
 ### Rate Limits
 The rate limits for external match endpoints are as follows: 
 - **Quote**: 100 requests per minute
-- **Assemble**: 5 _unsettled_ bundles per minute. That is, if an assembled bundle is submitted on-chain, the rate limiter will reset. 
+- **Assemble (Exclusive Bundle)**: 5 _unsettled_ bundles per minute. That is, if an assembled bundle is submitted on-chain, the rate limiter will reset. 
+- **Assemble (Shared Bundle)**: 50 _unsettled_ shared bundles per minute. A shared bundle is an assembled bundle that the relayer may send to multiple external parties, rather than enforcing that only one external party can settle the bundle. See [`examples/shared_bundle.py`](examples/shared_bundle.py) for an example of how to assemble a shared bundle.
 If an assembled match is not settled on-chain, the rate limiter will remove one token from the per-minute allowance.
 
 ### Supported Tokens

--- a/examples/modify_order_before_assembly.py
+++ b/examples/modify_order_before_assembly.py
@@ -5,10 +5,6 @@ from renegade import OrderSide, ExternalOrder
 from renegade.client import AssembleExternalMatchOptions
 from examples.helpers import BASE_MINT, QUOTE_MINT, get_client, execute_bundle_async
 
-# Constants
-BASE_MINT = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a"  # Testnet wETH
-QUOTE_MINT = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"  # Testnet USDC
-
 async def fetch_quote_and_execute() -> None:
     """Fetch a quote, modify it, and execute the trade."""
     # Create the order

--- a/examples/shared_bundle.py
+++ b/examples/shared_bundle.py
@@ -1,0 +1,47 @@
+import asyncio
+from renegade.client import AssembleExternalMatchOptions
+from renegade.types import OrderSide, ExternalOrder
+from examples.helpers import (
+    BASE_MINT, QUOTE_MINT, get_client,
+    execute_bundle_async
+)
+
+async def fetch_quote_and_execute() -> None:
+    """Fetch a quote, validate it, and execute the trade.
+    
+    Raises:
+        ValueError: If no quote is found
+    """
+    # Create the order
+    order = ExternalOrder(
+        base_mint=BASE_MINT,
+        quote_mint=QUOTE_MINT,
+        side=OrderSide.SELL,
+        quote_amount=30_000_000,  # $30 USDC
+        min_fill_size=3_000_000,  # $3 USDC minimum
+    )
+
+    # Fetch a quote from the relayer
+    print("Fetching quote...")
+    client = get_client()
+    quote = await client.request_quote(order)
+    if not quote:
+        raise ValueError("No quote found")
+    
+    # Print quote details
+    print(f"\nQuote details:")
+    print(f"Receive amount: {quote.quote.receive.amount}")
+    print(f"Total fees: {quote.quote.fees.total()}")
+    
+    # Assemble the quote into a bundle
+    print("\nAssembling quote...")
+    options = AssembleExternalMatchOptions().with_allow_shared(True)
+    bundle = await client.assemble_quote_with_options(quote, options)
+    if not bundle:
+        raise ValueError("No bundle found")
+
+    # Execute the bundle
+    await execute_bundle_async(bundle)
+
+if __name__ == "__main__":
+    asyncio.run(fetch_quote_and_execute()) 

--- a/renegade/client.py
+++ b/renegade/client.py
@@ -128,6 +128,7 @@ class RequestQuoteOptions:
 @dataclass
 class AssembleExternalMatchOptions:
     do_gas_estimation: bool = False
+    allow_shared: bool = False
     receiver_address: Optional[str] = None
     updated_order: Optional[ExternalOrder] = None
     request_gas_sponsorship: bool = False
@@ -139,6 +140,10 @@ class AssembleExternalMatchOptions:
 
     def with_gas_estimation(self, do_gas_estimation: bool) -> "AssembleExternalMatchOptions":
         self.do_gas_estimation = do_gas_estimation
+        return self
+    
+    def with_allow_shared(self, allow_shared: bool) -> "AssembleExternalMatchOptions":
+        self.allow_shared = allow_shared
         return self
 
     def with_receiver_address(self, receiver_address: str) -> "AssembleExternalMatchOptions":
@@ -375,6 +380,7 @@ class ExternalMatchClient:
         )
         request = AssembleExternalMatchRequest(
             do_gas_estimation=options.do_gas_estimation,
+            allow_shared=options.allow_shared,
             receiver_address=options.receiver_address,
             signed_quote=signed_quote,
             updated_order=options.updated_order,

--- a/renegade/types.py
+++ b/renegade/types.py
@@ -146,6 +146,7 @@ class ExternalQuoteResponse(BaseModelWithConfig):
 
 class AssembleExternalMatchRequest(BaseModelWithConfig):
     do_gas_estimation: bool = False
+    allow_shared: bool = False
     receiver_address: Optional[str] = None
     signed_quote: Optional[ApiSignedExternalQuote] = None
     updated_order: Optional[ExternalOrder] = None


### PR DESCRIPTION
### Purpose
This PR exposes the shared bundles option to the client and adds an example for its use.

### Testing
- [x] Test example in testnet