### PR TITLE
renegade: Add Base clients

### DIFF
--- a/examples/base_sepolia_match.py
+++ b/examples/base_sepolia_match.py
@@ -1,0 +1,46 @@
+import asyncio
+from renegade.types import OrderSide, ExternalOrder
+from examples.helpers import get_client, execute_bundle_async
+
+# Base Sepolia mint addresses - fill these in
+BASE_MINT = "0x31a5552AF53C35097Fdb20FFf294c56dc66FA04c"  # Base Sepolia wETH
+QUOTE_MINT = "0xD9961Bb4Cb27192f8dAd20a662be081f546b0E74"  # Base Sepolia USDC
+
+async def fetch_quote_and_execute() -> None:
+    """Fetch a quote, validate it, and execute the trade.
+    
+    Raises:
+        ValueError: If no quote is found
+    """
+    # Create the order
+    order = ExternalOrder(
+        base_mint=BASE_MINT,
+        quote_mint=QUOTE_MINT,
+        side=OrderSide.SELL,
+        quote_amount=30_000_000,  # $30 USDC
+        min_fill_size=3_000_000,  # $3 USDC minimum
+    )
+
+    # Fetch a quote from the relayer (using Base Sepolia)
+    print("Fetching quote...")
+    client = get_client(base=True)  # Use Base Sepolia client
+    quote = await client.request_quote(order)
+    if not quote:
+        raise ValueError("No quote found")
+    
+    # Print quote details
+    print(f"\nQuote details:")
+    print(f"Receive amount: {quote.quote.receive.amount}")
+    print(f"Total fees: {quote.quote.fees.total()}")
+    
+    # Assemble the quote into a bundle
+    print("\nAssembling quote...")
+    bundle = await client.assemble_quote(quote)
+    if not bundle:
+        raise ValueError("No bundle found")
+
+    # Execute the bundle
+    await execute_bundle_async(bundle)
+
+if __name__ == "__main__":
+    asyncio.run(fetch_quote_and_execute()) 

--- a/examples/helpers.py
+++ b/examples/helpers.py
@@ -49,6 +49,7 @@ async def execute_bundle_async(bundle: ExternalMatchResponse) -> None:
 
     print("Submitting bundle...")
     tx = bundle.match_bundle.settlement_tx
+    print(tx)
     tx['to'] = Web3.to_checksum_address(tx['to'])
     
     # Add required transaction fields
@@ -103,7 +104,7 @@ def execute_bundle_sync(bundle: ExternalMatchResponse) -> None:
     tx_hash = w3.eth.send_transaction(tx)
     print(f"Transaction submitted: 0x{tx_hash.hex()}")
 
-def get_client() -> ExternalMatchClient:
+def get_client(base: bool = False) -> ExternalMatchClient:
     """Get an ExternalMatchClient instance from environment variables.
     
     Returns:
@@ -119,4 +120,7 @@ def get_client() -> ExternalMatchClient:
     if not api_key or not api_secret:
         raise ValueError("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
 
-    return ExternalMatchClient.new_arbitrum_sepolia_client(api_key, api_secret)
+    if base:
+        return ExternalMatchClient.new_base_sepolia_client(api_key, api_secret)
+    else:
+        return ExternalMatchClient.new_arbitrum_sepolia_client(api_key, api_secret)

--- a/renegade/client.py
+++ b/renegade/client.py
@@ -13,6 +13,8 @@ from importlib.metadata import version
 
 ARBITRUM_SEPOLIA_BASE_URL = "https://arbitrum-sepolia.auth-server.renegade.fi"
 ARBITRUM_ONE_BASE_URL = "https://arbitrum-one.auth-server.renegade.fi"
+BASE_SEPOLIA_BASE_URL = "https://base-sepolia.auth-server.renegade.fi"
+BASE_MAINNET_BASE_URL = "https://base-mainnet.auth-server.renegade.fi"
 
 RENEGADE_API_KEY_HEADER = "x-renegade-api-key"
 RENEGADE_SDK_VERSION_HEADER = "x-renegade-sdk-version"
@@ -217,6 +219,19 @@ class ExternalMatchClient:
         return cls(api_key, api_secret, ARBITRUM_SEPOLIA_BASE_URL)
 
     @classmethod
+    def new_base_sepolia_client(cls, api_key: str, api_secret: str) -> "ExternalMatchClient":
+        """Create a new client configured for Base Sepolia testnet.
+
+        Args:
+            api_key: The API key for authentication
+            api_secret: The API secret for request signing
+
+        Returns:
+            A new ExternalMatchClient configured for Base Sepolia
+        """
+        return cls(api_key, api_secret, BASE_SEPOLIA_BASE_URL)
+
+    @classmethod
     @deprecated(version="0.1.8", reason="Use new_arbitrum_sepolia_client instead")
     def new_sepolia_client(cls, api_key: str, api_secret: str) -> "ExternalMatchClient":
         """Create a new client configured for the Arbitrum Sepolia testnet.
@@ -242,6 +257,19 @@ class ExternalMatchClient:
             A new ExternalMatchClient configured for Arbitrum One
         """
         return cls(api_key, api_secret, ARBITRUM_ONE_BASE_URL)
+    
+    @classmethod
+    def new_base_mainnet_client(cls, api_key: str, api_secret: str) -> "ExternalMatchClient":
+        """Create a new client configured for Base mainnet.
+
+        Args:
+            api_key: The API key for authentication
+            api_secret: The API secret for request signing
+
+        Returns:
+            A new ExternalMatchClient configured for Base mainnet
+        """
+        return cls(api_key, api_secret, BASE_MAINNET_BASE_URL)
 
     @classmethod
     @deprecated(version="0.1.8", reason="Use new_arbitrum_one_client instead")


### PR DESCRIPTION
### Purpose
This PR adds Base sepolia and mainnet client configs to the external match client, and includes an example using a Base Sepolia client.

### Testing
- [x] Tested an external match on Base, verification fails for the moment while [this pr](https://github.com/renegade-fi/renegade-solidity-contracts/pull/122) has not yet been deployed.